### PR TITLE
More arguments #10 ; launcher auto-detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 get:
-	go get github.com/gotk3/gotk3@289cfb6dbf32de11dd2a392e86de4a144ac6be48
+	go get github.com/gotk3/gotk3
 	go get github.com/gotk3/gotk3/gdk
 	go get github.com/gotk3/gotk3/glib
 	go get github.com/dlasky/gotk3-layershell/layershell

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Fully configurable (w/ command line arguments and css) dock, written in Go, aime
 - `go` 1.16 (just to build)
 - `gtk3`
 - `gtk-layer-shell`
-- `nwg-launchers`: optionally. You may use another launcher, see help.
+- [nwg-drawer](https://github.com/nwg-piotr/nwg-drawer) or
+[nwg-launchers](https://github.com/nwg-piotr/nwg-launchers): optionally. You may use another launcher, see help.
 
 ### Steps
 

--- a/README.md
+++ b/README.md
@@ -10,24 +10,19 @@ Fully configurable (w/ command line arguments and css) dock, written in Go, aime
 
 ### Requirements
 
-- `go` up to 1.16.2: just to build. See the note below.
+- `go` 1.16 (just to build)
 - `gtk3`
 - `gtk-layer-shell`
 - `nwg-launchers`: optionally. You may use another launcher, see help.
 
-**Note**: For go 1.16.3 a more recent gotk3 version would be necessary. For now I tried the
- `86f85cbecd0b990beab32a3471b08ad3cdd8f93b` commit and it worked, but would give me deprecation warnings.
- It also needed some changes to the code, as `glib.TimeoutAdd` now returns just int, w/o `error`. Let's wait a little
-  bit more.
-
 ### Steps
 
 1. Clone the repository, cd into it.
-2. Install necessary golang libraries with `make get`. First time it may take awhile, be patient.
+2. Install golang libraries with `make get`. First time it may take ages, be patient.
 3. `make build`
 4. `sudo make install`
 
-Or you may skip 1 and 2, and try just `sudo make install`. You've downloaded the binary in the `/bin` directory.
+If your machine is x86_64, you may skip 2 and 3, and just install the provided binary with `sudo make install`.
 
 ## Running
 
@@ -37,8 +32,8 @@ Either start the dock permanently in the sway config file,
 exec nwg-dock [arguments]
 ```
 
-or assign the command to some key binding. Running the command again kills existing program instance, so you may use
-the same key to open and close the dock.
+or assign the command to some key binding. Running the command again kills existing program instance, so that
+you could use the same key to open and close the dock.
 
 ## Running in autohiDe mode
 
@@ -61,7 +56,7 @@ Usage of nwg-dock:
   -a string
     	Alignment in full width/height: "start", "center" or "end" (default "center")
   -c string
-    	Command assigned to the launcher button (default "nwggrid -p")
+    	Command assigned to the launcher button
   -d	auto-hiDe: show dock when hotspot hovered, close when left or a button clicked
   -f	take Full screen width/height
   -i int
@@ -76,6 +71,10 @@ Usage of nwg-dock:
     	Margin Right
   -mt int
     	Margin Top
+  -nolauncher
+    	don't show launcher button switcher
+  -nows
+    	don't show the workspace switcher
   -o string
     	name of Output to display the dock on
   -p string

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Fully configurable (w/ command line arguments and css) dock, written in Go, aime
 - `gtk3`
 - `gtk-layer-shell`
 - [nwg-drawer](https://github.com/nwg-piotr/nwg-drawer) or
-[nwg-launchers](https://github.com/nwg-piotr/nwg-launchers): optionally. You may use another launcher, see help.
+[nwg-launchers](https://github.com/nwg-piotr/nwg-launchers): optionally. You may use another launcher (see help),
+or none at all. The launcher button won't show up, if so.
 
 ### Steps
 

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/nwg-piotr/nwg-dock
 go 1.16
 
 require (
-	github.com/allan-simon/go-singleinstance v0.0.0-20210120080615-d0997106ab37 // indirect
+	github.com/allan-simon/go-singleinstance v0.0.0-20210120080615-d0997106ab37
 	github.com/dlasky/gotk3-layershell v0.0.0-20210331230524-5cca0b819261
 	github.com/gotk3/gotk3 v0.5.3-0.20210223154815-289cfb6dbf32
-	github.com/joshuarubin/go-sway v0.0.3
+	github.com/joshuarubin/go-sway v0.0.4
 	golang.org/x/mobile v0.0.0-20210220033013-bdb1ca9a1e08 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/gotk3/gotk3 v0.5.3-0.20210223154815-289cfb6dbf32 h1:wE6C/HgLUBHi8YhHl
 github.com/gotk3/gotk3 v0.5.3-0.20210223154815-289cfb6dbf32/go.mod h1:/hqFpkNa9T3JgNAE2fLvCdov7c5bw//FHNZrZ3Uv9/Q=
 github.com/joshuarubin/go-sway v0.0.3 h1:uuY+dAMz+iAJvso+DP7TSRczDWhaV47nEPHJoRDOqjA=
 github.com/joshuarubin/go-sway v0.0.3/go.mod h1:qcDd6f25vJ0++wICwA1BainIcRC67p2Mb4lsrZ0k3/k=
+github.com/joshuarubin/go-sway v0.0.4 h1:dpmIwQ/LytG+oMrjmaVKdk1aPdW2feXK/+wAcLKIx4A=
+github.com/joshuarubin/go-sway v0.0.4/go.mod h1:qcDd6f25vJ0++wICwA1BainIcRC67p2Mb4lsrZ0k3/k=
 github.com/joshuarubin/lifecycle v1.0.0 h1:N/lPEC8f+dBZ1Tn99vShqp36LwB+LI7XNAiNadZeLUQ=
 github.com/joshuarubin/lifecycle v1.0.0/go.mod h1:sRy++ATvR9Ee21tkRdFkQeywAWvDsue66V70K0Dnl54=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strconv"
@@ -18,7 +19,7 @@ import (
 	"github.com/gotk3/gotk3/gtk"
 )
 
-const version = "0.1.2"
+const version = "0.1.3"
 
 var (
 	appDirs                            []string
@@ -34,6 +35,7 @@ var (
 	imgSizeScaled                      int
 	currentWsNum, targetWsNum          int64
 	dockWindow                         *gtk.Window
+	lCmd                               string
 )
 
 // Flags
@@ -47,14 +49,14 @@ var position = flag.String("p", "bottom", "Position: \"bottom\", \"top\" or \"le
 var exclusive = flag.Bool("x", false, "set eXclusive zone: move other windows aside; overrides the \"-l\" argument")
 var imgSize = flag.Int("i", 48, "Icon size")
 var layer = flag.String("l", "overlay", "Layer \"overlay\", \"top\" or \"bottom\"")
-var launcherCmd = flag.String("c", "nwggrid -p", "Command assigned to the launcher button")
+var launcherCmd = flag.String("c", "", "Command assigned to the launcher button")
 var alignment = flag.String("a", "center", "Alignment in full width/height: \"start\", \"center\" or \"end\"")
 var marginTop = flag.Int("mt", 0, "Margin Top")
 var marginLeft = flag.Int("ml", 0, "Margin Left")
 var marginRight = flag.Int("mr", 0, "Margin Right")
 var marginBottom = flag.Int("mb", 0, "Margin Bottom")
 var noWs = flag.Bool("nows", false, "don't show the workspace switcher")
-var noLauncher = flag.Bool("nolauncher", false, "don't show launcher button switcher")
+var noLauncher = flag.Bool("nolauncher", false, "don't show the launcher button")
 
 func buildMainBox(tasks []task, vbox *gtk.Box) {
 	mainBox.Destroy()
@@ -180,7 +182,7 @@ func buildMainBox(tasks []task, vbox *gtk.Box) {
 		mainBox.PackStart(wsButton, false, false, 0)
 	}
 
-	if !*noLauncher {
+	if !*noLauncher && *launcherCmd != "" {
 		button, _ := gtk.ButtonNew()
 		image, err := createImage("/usr/share/nwg-dock/images/grid.svg", imgSizeScaled)
 		if err == nil {
@@ -188,7 +190,9 @@ func buildMainBox(tasks []task, vbox *gtk.Box) {
 			button.SetAlwaysShowImage(true)
 
 			button.Connect("clicked", func() {
-				launch(*launcherCmd)
+				elements := strings.Split(*launcherCmd, " ")
+				cmd := exec.Command(elements[0], elements[1:]...)
+				go cmd.Run()
 			})
 			button.Connect("enter-notify-event", cancelClose)
 		}
@@ -288,6 +292,20 @@ func main() {
 		os.Exit(0)
 	}
 	defer lockFile.Close()
+
+	if !*noLauncher && *launcherCmd == "" {
+		if isCommand("nwg-drawer") {
+			*launcherCmd = "nwg-drawer"
+		} else if isCommand("nwggrid") {
+			*launcherCmd = "nwggrid -p"
+		}
+
+		if *launcherCmd != "" {
+			println(fmt.Sprintf("Using auto-detected launcher command: '%s'", *launcherCmd))
+		} else {
+			println("Neither 'nwg-drawer' nor 'nwggrid' command found, and no other launcher specified; hiding the launcher button.")
+		}
+	}
 
 	configDirectory = configDir()
 	// if doesn't exist:

--- a/tools.go
+++ b/tools.go
@@ -938,3 +938,18 @@ func listMonitors() ([]gdk.Monitor, error) {
 	}
 	return monitors, nil
 }
+
+// Returns output of a CLI command with optional arguments
+func getCommandOutput(command string) string {
+	out, err := exec.Command("sh", "-c", command).Output()
+	if err != nil {
+		return ""
+	}
+
+	return strings.TrimSpace(string(out))
+}
+
+func isCommand(command string) bool {
+	cmd := strings.Fields(command)[0]
+	return getCommandOutput(fmt.Sprintf("command -v %s ", cmd)) != ""
+}


### PR DESCRIPTION
- added `-nows` and `-nolauncher` arguments to disable the workspace switcher and the launcher button (closes #10)
- added auto-detection of `nwg-drawer` or `nwggrid` command, if available