### PR TITLE
properly format error messages

### DIFF
--- a/main.go
+++ b/main.go
@@ -357,7 +357,7 @@ func main() {
 		if err == nil {
 			layershell.SetMonitor(win, output2mon[*targetOutput])
 		} else {
-			println(err)
+			println(fmt.Sprintf("%s", err))
 		}
 	}
 
@@ -478,7 +478,7 @@ func main() {
 
 		mRefProvider, _ := gtk.CssProviderNew()
 		if err := mRefProvider.LoadFromPath(filepath.Join(dataHome, "nwg-dock/hotspot.css")); err != nil {
-			println(err)
+			println(fmt.Sprintf("%s", err))
 		}
 
 		if *targetOutput == "" {

--- a/tools.go
+++ b/tools.go
@@ -426,7 +426,7 @@ func createPixbuf(icon string, size int) (*gdk.Pixbuf, error) {
 	if strings.HasPrefix(icon, "/") {
 		pixbuf, err := gdk.PixbufNewFromFileAtSize(icon, size, size)
 		if err != nil {
-			println(err)
+			println(fmt.Sprintf("%s", err))
 			return nil, err
 		}
 		return pixbuf, nil


### PR DESCRIPTION
Print error messages instead of pointers